### PR TITLE
dino: set num_queries to 900 to get mAP>0.5 after 12 epochs.

### DIFF
--- a/notebooks/tao_launcher_starter_kit/dino/specs/evaluate.yaml
+++ b/notebooks/tao_launcher_starter_kit/dino/specs/evaluate.yaml
@@ -17,7 +17,7 @@ model:
   num_feature_levels: 4
   dec_layers: 6
   enc_layers: 6
-  num_queries: 300
+  num_queries: 900
   num_select: 100
   dropout_ratio: 0.0
   dim_feedforward: 2048

--- a/notebooks/tao_launcher_starter_kit/dino/specs/export.yaml
+++ b/notebooks/tao_launcher_starter_kit/dino/specs/export.yaml
@@ -12,7 +12,7 @@ model:
   num_feature_levels: 4
   dec_layers: 6
   enc_layers: 6
-  num_queries: 300
+  num_queries: 900
   num_select: 100
   dropout_ratio: 0.0
   dim_feedforward: 2048

--- a/notebooks/tao_launcher_starter_kit/dino/specs/infer.yaml
+++ b/notebooks/tao_launcher_starter_kit/dino/specs/infer.yaml
@@ -21,7 +21,7 @@ model:
   num_feature_levels: 4
   dec_layers: 6
   enc_layers: 6
-  num_queries: 300
+  num_queries: 900
   num_select: 100
   dropout_ratio: 0.0
   dim_feedforward: 2048

--- a/notebooks/tao_launcher_starter_kit/dino/specs/train.yaml
+++ b/notebooks/tao_launcher_starter_kit/dino/specs/train.yaml
@@ -27,7 +27,7 @@ model:
   num_feature_levels: 4
   dec_layers: 6
   enc_layers: 6
-  num_queries: 300
+  num_queries: 900
   num_select: 100
   dropout_ratio: 0.0
   dim_feedforward: 2048


### PR DESCRIPTION
As discussed [here](https://forums.developer.nvidia.com/t/the-tao-5-5-0-launcher-dino-notebook-is-not-working-with-default-settings/313194/1) and a few other threads on the forum, the default num_queries of 300 will lead to a mAP of ~0.0003 after 12 epochs when training on the coco 2017 dataset with the notebook.

This patch is the minimum you need to adapt to get to the advertised ~0.5 mAP and provide a solid baseline for people to experiment with this setup.